### PR TITLE
Fix Definition of "se" Object in "cv.saenet"

### DIFF
--- a/R/cv.saenet.R
+++ b/R/cv.saenet.R
@@ -188,7 +188,7 @@ cv.saenet <- function(x, y, pf, adWeight, weights, family = c("gaussian", "binom
   cvm  <- apply(cvm, c(1, 2), mean)
   
   min.id = which(cvm == min(cvm), arr.ind = TRUE)
-  se = cvse[min.id[1], min.id[2]]
+  se = cvse[min.id[1, 1], min.id[1, 2]]
   range = min(cvm) + se
   
   all.id = which(cvm < range, arr.ind = TRUE)


### PR DESCRIPTION
I ran `cv.saenet()` with `alpha=1` and noticed a "subscript out of bounds error". Note that `min.id[2] = min.id[2, 1]`. However, we want to retrieve the element in the first row and second column (I believe). I have therefore changed this to `min.id[1, 2]` and changed `min.id[1]` to `min.id[1, 1]` for added clarity.